### PR TITLE
Unify queries and mutations

### DIFF
--- a/lib/helpers/database_helper.dart
+++ b/lib/helpers/database_helper.dart
@@ -1,5 +1,4 @@
 import 'package:graphql/client.dart';
-import 'package:simple_todo_app/models/todo_model.dart';
 
 class DatabaseHelper {
   GraphQLClient getClient() {
@@ -21,86 +20,11 @@ class DatabaseHelper {
     return result.data;
   }
 
-  Future<Map<String, dynamic>?> runCreateMutation(GraphQLClient client, TodoModel todoModel) async {
-    const String addQuery = r'''
-    mutation($is_done: Boolean, $priority: Int, $todo: String, $user: uuid) {
-      insert_todos_one(object: {is_done: $is_done, priority: $priority, todo: $todo, user: $user}) {
-          created_at
-          id
-          is_done
-          priority
-          todo
-          user
-          }
-    }
-    ''';
-    final MutationOptions options = MutationOptions(document: gql(addQuery), variables: <String, dynamic>{
-      'is_done': todoModel.isDone,
-      'todo': todoModel.todo,
-      'priority': todoModel.priority,
-      'user': '07c42a78-d85f-46e8-a98b-2c3d45c3b52b',
-    });
+  Future<Map<String, dynamic>?> runMutation(GraphQLClient client, String mutationQuery, Map<String, dynamic> variables) async {
+    final MutationOptions options = MutationOptions(document: gql(mutationQuery), variables: variables);
     final QueryResult result = await client.mutate(options);
-
     if (result.hasException) {
       throw 'GraphQL Mutation Exception ${result.exception.toString()}';
-    }
-
-    return result.data;
-  }
-
-  Future<Map<String, dynamic>?> runEditMutation(GraphQLClient client, TodoModel todoModel) async {
-    const String editQuery = r'''
-    mutation EditTodo($_eq: Int, $is_done: Boolean, $priority: Int, $todo: String) {
-      update_todos(_set: {todo: $todo, priority: $priority, is_done: $is_done}, where: {id: {_eq: $_eq}}) {
-        returning {
-          created_at
-          id
-          is_done
-          priority
-          todo
-          user
-        }
-      }
-    }
-    ''';
-
-    final MutationOptions options = MutationOptions(document: gql(editQuery), variables: <String, dynamic>{
-      '_eq': todoModel.id,
-      'is_done': todoModel.isDone,
-      'priority': todoModel.priority,
-      'todo': todoModel.todo,
-    });
-    final QueryResult result = await client.mutate(options);
-
-    if (result.hasException) {
-      throw 'GraphQL Edit Mutation Exception ${result.exception.toString()}';
-    }
-
-    return result.data;
-  }
-
-  Future<Map<String, dynamic>?> runDeleteMutation(GraphQLClient client, TodoModel todoModel) async {
-    const String deleteQuery = r'''
-    mutation DeleteTodo($_eq: Int) {
-      delete_todos(where: {id: {_eq: $_eq}}) {
-        returning {
-          id
-        }
-      }
-    }
-    ''';
-
-    final MutationOptions options = MutationOptions(
-      document: gql(deleteQuery),
-      variables: <String, dynamic>{
-        '_eq': todoModel.id,
-      },
-    );
-    final QueryResult result = await client.mutate(options);
-
-    if (result.hasException) {
-      throw 'GraphQL Delete Mutation Exception ${result.exception.toString()}';
     }
 
     return result.data;

--- a/lib/providers/main_provider.dart
+++ b/lib/providers/main_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:graphql/client.dart';
 import 'package:simple_todo_app/helpers/database_helper.dart';
 import 'package:simple_todo_app/models/todo_model.dart';
+import 'package:simple_todo_app/queries.dart';
 
 class MainProvider with ChangeNotifier {
   GraphQLClient? client;
@@ -39,9 +40,16 @@ class MainProvider with ChangeNotifier {
 
   Future<String> addTodo(TodoModel todoModel) async {
     client ??= helper.getClient();
+    Map<String, dynamic> variables = {
+      'is_done': todoModel.isDone,
+      'todo': todoModel.todo,
+      'priority': todoModel.priority,
+      'user': '07c42a78-d85f-46e8-a98b-2c3d45c3b52b',
+    };
+
     Map<String, dynamic>? response;
     try {
-      response = await helper.runCreateMutation(client!, todoModel);
+      response = await helper.runMutation(client!, Queries.addQuery, variables);
     } catch (e) {
       return e.toString();
     }
@@ -58,9 +66,16 @@ class MainProvider with ChangeNotifier {
 
   Future<String> editTodo(TodoModel todoModel) async {
     client ??= helper.getClient();
+    Map<String, dynamic> variables = {
+      '_eq': todoModel.id,
+      'is_done': todoModel.isDone,
+      'priority': todoModel.priority,
+      'todo': todoModel.todo,
+    };
+
     Map<String, dynamic>? response;
     try {
-      response = await helper.runEditMutation(client!, todoModel);
+      response = await helper.runMutation(client!, Queries.editQuery, variables);
     } catch (e) {
       return e.toString();
     }
@@ -83,9 +98,13 @@ class MainProvider with ChangeNotifier {
 
   Future<String> deleteTodo(TodoModel todoModel) async {
     client ??= helper.getClient();
+    Map<String, dynamic> variables = {
+      '_eq': todoModel.id,
+    };
+
     Map<String, dynamic>? response;
     try {
-      response = await helper.runDeleteMutation(client!, todoModel);
+      response = await helper.runMutation(client!, Queries.deleteQuery, variables);
     } catch (e) {
       return e.toString();
     }

--- a/lib/queries.dart
+++ b/lib/queries.dart
@@ -1,0 +1,39 @@
+class Queries {
+  static const String addQuery = r'''
+    mutation($is_done: Boolean, $priority: Int, $todo: String, $user: uuid) {
+      insert_todos_one(object: {is_done: $is_done, priority: $priority, todo: $todo, user: $user}) {
+          created_at
+          id
+          is_done
+          priority
+          todo
+          user
+          }
+    }
+  ''';
+
+  static const String editQuery = r'''
+    mutation EditTodo($_eq: Int, $is_done: Boolean, $priority: Int, $todo: String) {
+      update_todos(_set: {todo: $todo, priority: $priority, is_done: $is_done}, where: {id: {_eq: $_eq}}) {
+        returning {
+          created_at
+          id
+          is_done
+          priority
+          todo
+          user
+        }
+      }
+    }
+  ''';
+
+  static const String deleteQuery = r'''
+    mutation DeleteTodo($_eq: Int) {
+      delete_todos(where: {id: {_eq: $_eq}}) {
+        returning {
+          id
+        }
+      }
+    }
+  ''';
+}


### PR DESCRIPTION
As these queries and mutations may be used elsewhere, it makes more sense to just unify queries and mutations into their own single methods and take the query and variables as perimeters.